### PR TITLE
Fixed the images under the projects section.

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -408,7 +408,7 @@ canvas {
     margin-right: 10px;
   }
   #projects .row img {
-    margin-left: 20px;
+    margin-left: 5px;
     margin-right: 20px;
   }
 }


### PR DESCRIPTION
Fixed.
The images under the projects section is not horizontally center aligned on phone. It's a bit more inclined towards the right.
Just change the properties of CSS